### PR TITLE
Make f31 and customisationId bigger as it's unknown if they will fit …

### DIFF
--- a/src/riderStatus.js
+++ b/src/riderStatus.js
@@ -142,7 +142,7 @@ export default function riderStatus(buffer) {
                         id: 21
                     },
                     customisationId: {
-                        type: "int32",
+                        type: "int64",
                         id: 22,
                     },
                     justWatching: {
@@ -174,7 +174,7 @@ export default function riderStatus(buffer) {
                         id: 29,
                     },
                     f31: {
-                      type: "int32",
+                      type: "int64",
                       id: 31,
                     },
                 }


### PR DESCRIPTION
…in an int32.

I believe this may fix the "failed to get status" error. These are the only two fields that I think might be larger than 32 bits.