### PR TITLE
change heading to int64

### DIFF
--- a/src/riderStatus.js
+++ b/src/riderStatus.js
@@ -114,7 +114,7 @@ export default function riderStatus(buffer) {
                         id: 12
                     },
                     heading: {
-                        type: "int32",
+                        type: "int64",
                         id: 13
                     },
                     lean: {


### PR DESCRIPTION
I managed to do a packet capture on a parsing error and discovered it's actually the heading field that occasionally switches to a value too large to fit in an int32.

I was able to verify that this version resolves the remaining protobuf error I had.