### PR TITLE
Adding more protobuf definitions - support for udp parsing

### DIFF
--- a/src/World.js
+++ b/src/World.js
@@ -1,5 +1,5 @@
 ﻿import Request from './Request';
-import riderStatus from './riderStatus'
+import { riderStatus } from './riderStatus';
 
 class World {
     constructor(worldId, tokenFn) {

--- a/src/ZwiftAccount.js
+++ b/src/ZwiftAccount.js
@@ -3,10 +3,19 @@ import Profile from './Profile'
 import World from './World'
 import Request from './Request';
 import Activity from './Activity';
+import { root, wrappedStatus } from './riderStatus';
 
 const TOKEN_REFRESH_MS = 10 * 60 * 1000;
 
 class ZwiftAccount {
+
+    static getZwiftProtocolRoot() {
+        return root;
+    }
+
+    static wrappedStatus(status) {
+        return wrappedStatus(status);
+    }
 
     constructor(username, password) {
         this.username = username;

--- a/src/riderStatus.js
+++ b/src/riderStatus.js
@@ -1,10 +1,8 @@
 /* eslint-disable indent */
 import protobuf from 'protobufjs';
 
-const extraVariables = ['roadID', 'rideOns', 'isTurning', 'isForward', 'cadence'];
-
-const proto = `syntax=\"proto3\";
-    message Status {
+const proto = `syntax="proto3";
+    message PlayerState {
         int32 id = 1;
         int64 worldTime = 2;
         int32 distance = 3;
@@ -30,9 +28,73 @@ const proto = `syntax=\"proto3\";
         int32 watchingRiderId = 28;
         int32 groupId = 29;
         int64 f31 = 31;
-    }`;
-const root = protobuf.parse(proto, { keepCase: true }).root;
-const Status = root.lookup("Status");
+    }
+    message ClientToServer {
+        int32 connected = 1;
+        int32 rider_id = 2;
+        int64 world_time = 3;
+        PlayerState state = 7;
+        int32 seqno = 4;
+        int64 tag8 = 8;
+        int64 tag9 = 9;
+        int64 last_update = 10;
+        int64 tag11 = 11;
+        int64 last_player_update = 12;
+    }
+    
+    message UnknownMessage1 {
+        // string firstName=7;
+        // string lastName=8;
+        // string timestamp=17;
+    }
+    
+    message UnknownMessage {
+        // int64 tag1=1;
+        // UnknownMessage1 tag4=4;
+    }
+    
+    message ServerToClient {
+        int32 tag1 = 1;
+        int32 rider_id = 2;
+        int64 world_time = 3;
+        int32 seqno = 4;
+        repeated PlayerState player_states = 8;
+        repeated UnknownMessage player_updates = 9;
+        int64 tag11 = 11;
+        int64 tag17 = 17;
+        int32 num_msgs = 18;
+        int32 msgnum = 19;
+    }
+    
+    message WorldAttributes {
+        int32 world_id = 1;
+        string name = 2;
+        int64 tag3 = 3;
+        int64 tag5 = 4;
+        int64 world_time = 6;
+        int64 clock_time = 7;
+    }
+    
+    message WorldAttribute {
+        int64 world_time = 2;
+    }
+    
+    message EventSubgroupProtobuf {
+        int32 id = 1;
+        string name = 2;
+        int32 rules = 8;
+        int32 route = 22;
+        int32 laps = 25;
+        int32 startLocation = 29;
+        int32 label = 30;
+        int32 paceType = 31;
+        int32 jerseyHash = 36;
+    }
+
+    `;
+export const root = protobuf.parse(proto, { keepCase: true }).root;
+
+const Status = root.lookup('PlayerState');
 
 class PlayerStateWrapper {
     constructor(state) {
@@ -103,6 +165,10 @@ class PlayerStateHandler {
     }
 }
 
-export default function riderStatus(buffer) {
-    return new Proxy(Status.decode(buffer), new PlayerStateHandler());
-};
+export function wrappedStatus(status) {
+    return new Proxy(status, new PlayerStateHandler());
+}
+
+export function riderStatus(buffer) {
+    return wrappedStatus(Status.decode(buffer));
+}


### PR DESCRIPTION
This is a proposed change. I've added more protobuf definitions to support parsing the Zwift UDP traffic.

In order to do so, I had to change some of the export structure. Notably riderStatus.js now uses named exports and ZwiftAccount exposes two static methods to allow access to the protobuf definitions and to allow wrapping status objects to decode the bitwise encoded fields using the PlayerStateWrapper.

Note that I've also renamed Status in the protobuf definition to PlayerState to align with what I believe Zwift calls the message internally (based on strings visible in the Zwift binary).