### PR TITLE
Add refresh token support to ZwiftAccount

### DIFF
--- a/src/ZwiftAccount.js
+++ b/src/ZwiftAccount.js
@@ -7,12 +7,16 @@ const Activity = require('./Activity')
 const TOKEN_REFRESH_MS = 10 * 60 * 1000
 
 class ZwiftAccount {
-    constructor(username, password) {
+    constructor(username, password, refreshToken = null) {
         this.username = username
         this.password = password
 
         this.tokenPromise = null
         this.tokenDate = null
+
+        this.refreshToken = refreshToken
+        this.refreshTokenExpiration = 0
+        this.accessTokenExpiration = 0
 
         this.getAccessToken = this.getAccessToken.bind(this)
     }
@@ -34,11 +38,31 @@ class ZwiftAccount {
     }
 
     getAccessToken() {
-        if (!this.tokenPromise || (new Date().getTime() - this.tokenDate.getTime() > TOKEN_REFRESH_MS)) {
-            this.tokenDate = new Date()
-            this.tokenPromise = getAccessToken(this.username, this.password)
+        const now = new Date()
+        if (!this.tokenPromise || (now.getTime() > this.accessTokenExpiration)) {
+            this.getNewTokens()
         }
 
+        return this.tokenPromise
+    }
+
+    getRefreshToken() {
+        return this.getAccessToken().then(() => {
+            return this.refreshToken, this.refreshTokenExpiration
+        })
+    }
+
+    getNewTokens() {
+        const now = new Date()
+        this.tokenDate = now
+        this.tokenPromise = getAccessToken(this.username, this.password, this.refreshToken).then((response) => {
+            const now = new Date()
+            this.accessTokenExpiration = now.getTime() + ((response.data.expires_in - 5) * 1000)
+            this.refreshTokenExpiration  = now.getTime() + ((response.data.refresh_expires_in - 5) * 1000)
+            this.refreshToken = response.data.refresh_token
+            this.accessToken = response.data.access_token
+            return response.data.access_token, this.accessTokenExpiration
+        })
         return this.tokenPromise
     }
 }

--- a/src/ZwiftAccount.js
+++ b/src/ZwiftAccount.js
@@ -48,7 +48,7 @@ class ZwiftAccount {
 
     getRefreshToken() {
         return this.getAccessToken().then(() => {
-            return this.refreshToken, this.refreshTokenExpiration
+            return this.refreshToken
         })
     }
 
@@ -61,7 +61,7 @@ class ZwiftAccount {
             this.refreshTokenExpiration  = now.getTime() + ((response.data.refresh_expires_in - 5) * 1000)
             this.refreshToken = response.data.refresh_token
             this.accessToken = response.data.access_token
-            return response.data.access_token, this.accessTokenExpiration
+            return response.data.access_token
         })
         return this.tokenPromise
     }

--- a/src/getAccessToken.js
+++ b/src/getAccessToken.js
@@ -1,19 +1,25 @@
 ﻿const axios = require('axios')
 const qs = require('qs')
 
-module.exports = function getAccessToken(username, password) {
-    const data = {
-        "client_id": "Zwift_Mobile_Link",
-        "username": username,
-        "password": password,
-        "grant_type": "password",
+module.exports = function getAccessToken(username, password, refreshToken = null) {
+    let data
+    if (refreshToken) {
+        data = {
+            "client_id": "Zwift_Mobile_Link",
+            "refresh_token": refreshToken,
+            "grant_type": "refresh_token",
+        }
+    } else {
+        data = {
+            "client_id": "Zwift_Mobile_Link",
+            "username": username,
+            "password": password,
+            "grant_type": "password",
+        }
     }
 
     return axios.post('/auth/realms/zwift/tokens/access/codes',
         qs.stringify(data), {
             baseURL: 'https://secure.zwift.com'
-        })
-        .then(function (response) {
-            return response.data.access_token
         })
 }

--- a/src/riderStatus.js
+++ b/src/riderStatus.js
@@ -8,6 +8,12 @@ const TURN_SIGNALS = {
     STRAIGHT: 'straight'
 }
 
+const COURSES = {
+    WATOPIA: 3,
+    RICHMOND: 4,
+    LONDON: 5
+}
+
 class PlayerStateWrapper {
     constructor(state) {
         this.riderStatus = state
@@ -26,6 +32,16 @@ class PlayerStateWrapper {
     get isForward() {
         // eslint-disable-next-line no-bitwise
         return ((this.riderStatus.f19 & 8) !== 0)
+    }
+
+    get course() {
+        // eslint-disable-next-line no-bitwise
+        return ((this.riderStatus.f19 & 0xff0000) >> 16)
+    }
+
+    get world() {
+        //world defined in prefs.xml seems to be course - 2
+        return this.course() - 2
     }
 
     get roadID() {
@@ -121,5 +137,6 @@ function riderStatus(buffer) {
 module.exports = {
     wrappedStatus,
     riderStatus,
-    TURN_SIGNALS
+    TURN_SIGNALS,
+    COURSES
 }


### PR DESCRIPTION
This change allows instantiating a ZwiftAccount with a refresh token instead of a username/password pair. The current lifetime of a refresh token is 30 days, so this is a convenient way to avoid prompting the user for a password as long as they use the app every 30 days. Note that a new refresh token is passed back every time the tokens are refreshed, so apps that store the token should retrieve the new one each time they run.

Note that this did change the return from getAccessToken.js to expose all of the data in the response. I wasn't sure if anyone was using that return directly. I can make it backward compatible if need be.

I also added the expiration times for the tokens to the return from the getAccessToken and getRefreshToken promises.