### PR TITLE
ZML emulation prototype

### DIFF
--- a/src/Profile.js
+++ b/src/Profile.js
@@ -1,5 +1,6 @@
 ﻿const Request = require('./Request')
 const zwiftProtobuf = require('./zwiftProtobuf')
+const ZwiftAppConnection = require('./ZwiftAppConnection')
 const Profiles = zwiftProtobuf.lookup('Profiles')
 
 class Profile {
@@ -130,6 +131,11 @@ class Profile {
     if (!this.id) {
       throw new Error('A player id is required - account.getProfile(playerId)')
     }
+  }
+
+  getAppConnection() {
+    this.checkId()
+    return new ZwiftAppConnection(this.request, this.id)
   }
 }
 

--- a/src/Request.js
+++ b/src/Request.js
@@ -33,6 +33,7 @@ class Request {
         return this.send(url, 'post', data, acceptType, responseType)
     }
 
+
     send(url, method, data, acceptType, responseType) {
         return _queue.add().then(() => {
             return this.tokenFn().then(token => {
@@ -53,7 +54,7 @@ class Request {
                     .then(function (response) {
                         return response.data;
                     });
-            });
+            })
         });
     }
 

--- a/src/ZwiftAppConnection.js
+++ b/src/ZwiftAppConnection.js
@@ -1,0 +1,195 @@
+'use strict';
+const os = require("os")
+const zwiftProtobuf = require('./zwiftProtobuf')
+const EventEmitter = require('events')
+const net = require('net')
+const fs = require("fs")
+const PhoneToGame = zwiftProtobuf.lookup('PhoneToGame')
+const GameToPhone = zwiftProtobuf.lookup('GameToPhone')
+
+let index = 1
+function savePacket(data) {
+  while (fs.existsSync(`packet.${index++}`));
+  fs.writeFileSync(`packet.${index++}`, data)
+}
+
+function localIpAddress() {
+  const ifaces = os.networkInterfaces()
+  let address
+
+  for (let dev in ifaces) {
+    const iface = ifaces[dev].filter(function(details) {
+      return details.family === 'IPv4' && details.internal === false;
+    });
+
+    if(iface.length > 0){
+      address = iface[0].address
+      break
+    }
+  }
+  return address
+}
+
+class LPDataHandler extends EventEmitter {
+  constructor() {
+    super()
+    this._partialMessage = null
+    this._messageLen = 0
+  }
+
+  _deliverMessage(msg) {
+    this.emit('data', msg)
+  }
+
+  addData(data) {
+    let buf = data
+    if (this._partialMessage) {
+      const lenNeeded = this._messageLen - this._partialMessage.length
+      if (this._messageLen <= (this._partialMessage.len() + data.len())) {
+        this._deliverMessage(Buffer.concat([this._partialMessage, buf.slice(0, lenNeeded)]))
+        this._partialMessage = null
+        buf = buf.slice(lenNeeded)
+      } else {
+        this._partialMessage = Buffer.concat(this._partialMessage)
+        buf = buf.slice(buf.length)
+      }
+    }
+    while (buf.length){
+      this._messageLen = buf.readUInt32BE(0)
+      buf = buf.slice(4)
+      if (buf.length < this._messageLen) {
+        this._partialMessage = buf
+        buf = buf.slice(buf.length)
+      } else {
+        this._deliverMessage(buf.slice(0, this._messageLen))
+        buf = buf.slice(this._messageLen)
+      }
+    }
+  }
+}
+
+class ZwiftAppConnection extends EventEmitter {
+  constructor (request, playerId) {
+    super()
+    this._seqno = 1
+    this._packetNo = 0
+    this._playerId = playerId
+    this._request = request
+    this._lpDataHandler = new LPDataHandler()
+    this._lpDataHandler.on('data', (data) => this._handleData(data))
+    this._server = net.createServer((socket) => {
+    }).on('error', (err) => {
+      throw err
+    }).on('listening', () => {
+      this._registerPhone(localIpAddress(), this._server.address().port)
+    }).on('connection', (socket) => {
+      if (this._socket){
+        this._socket.pause()
+        this._socket.end()
+        this._socket = null
+      }
+      this._socket = socket
+      this._socket.on('data', (data) => {
+        this._lpDataHandler.addData(data)
+      })
+      this._handleConnection()
+    })
+    this._server.listen(0, '0.0.0.0')
+  }
+
+  stop() {
+    if (this._socket) {
+      this._socket.pause()
+      this._socket.end()
+      this._socket = null
+    }
+    this._server.close()
+  }
+
+  _registerPhone(address, port) {
+    const data = {
+      "mobileEnvironment": {
+        "appBuild": 355,
+        "appDisplayName": "Mobile Link",
+        "appVersion": "2.1.11",
+        "systemHardware": "iphone 10,6",
+        "systemOS": "iOS",
+        "systemOSVersion": "11.2.1"
+      },
+      "phoneAddress": address,
+      "port": port,
+      "protocol": "TCP"
+    }
+    this._request.send('/relay/profiles/me/phone', 'PUT', data, 'application/json', 'json')
+  }
+
+  _handleConnection() {
+    console.log("sending message 1")
+    this._sendMessage({
+      'id': this._playerId,
+      command: {
+        'seqno': this._seqno++,
+        'command': 28,
+        'subject': 0,
+        'f5': 0,
+        'f6': '',
+        'f7': 0,
+        'playerId': this._playerId
+      },
+      'packetNo': this._packetNo++
+    })
+    console.log("sending message 2")
+    this._sendMessage({
+      'id': this._playerId,
+      command: {
+        'seqno': this._seqno++,
+        'command': 29,
+        'subject': 0,
+        'f5': 0,
+        'f6': '',
+        'f7': 0,
+        'capabilities': {
+          'f1': 4,
+          'info': {
+            'appVersion': '2.1.1 (355)',
+            'systemOSVersion': '11.2.1',
+            'systemOS': 'iOS',
+            'systemHardware': 'iPhone'
+          }
+        }
+      },
+      'packetNo': this._packetNo++
+    })
+    this.emit('connected')
+  }
+
+  _sendMessage(phoneToGameMessage){
+    if (this._socket) {
+      const lenBuf = Buffer.allocUnsafe(4)
+      const buf = PhoneToGame.encode(phoneToGameMessage).finish()
+      lenBuf.writeUInt32BE(buf.length, 0)
+      this._socket.write(Buffer.concat([lenBuf, buf], buf.length + 4))
+    }
+  }
+
+  _handleData(data) {
+    try {
+      let msg = GameToPhone.decode(data)
+      this.emit('msg', msg)
+      for (let command of msg.commands) {
+        if (command.gtpc21 && command.gtpc21.gtpc21_6 && command.gtpc21.gtpc21_6.gtpc21_6_1) {
+          for (let gtpc21_6_1 of command.gtpc21.gtpc21_6.gtpc21_6_1) {
+            for (let info of gtpc21_6_1.playerInfos) {
+              this.emit('playerInfo', info)
+            }
+          }
+        }
+      }
+    } catch (err) {
+      console.log(err)
+      savePacket(data)
+    }
+  }
+}
+
+module.exports = ZwiftAppConnection

--- a/src/riderStatus.js
+++ b/src/riderStatus.js
@@ -18,7 +18,8 @@ const COURSE_TO_WORLD = {
     3: 1,
     4: 2,
     5: 3,
-    6: 1
+    6: 1,
+    7: 3
 }
 
 class PlayerStateWrapper {
@@ -47,8 +48,10 @@ class PlayerStateWrapper {
     }
 
     get world() {
-        //world defined in prefs.xml seems to be course - 2
-        return COURSE_TO_WORLD[this.course]
+        if (this.course in COURSE_TO_WORLD) {
+          return COURSE_TO_WORLD[this.course]
+        }
+        return this.course
     }
 
     get roadID() {

--- a/src/zwiftMessages.proto
+++ b/src/zwiftMessages.proto
@@ -151,3 +151,101 @@ message Profile {
 	string launchedGameClient = 108;
 	int32 currentActivityId = 109;
 }
+
+// ZML communication
+
+//  ZML server side
+
+message Vector3 {
+    float x = 1;
+    float y = 2;
+    float z = 3;
+}
+message PlayerInfo {
+    int32 id = 1;
+    int32 f2 = 2;
+    Vector3 position = 3;
+    string profile = 5;
+    int32 id2 = 6;
+    int32 f7 = 7;
+    string name = 11;
+    int32 countryCode = 12;
+    fixed32 worldTime = 13;
+    int32 f16 = 16;
+}
+
+message GTPC21_6_1 {
+    int32 seqno = 1;
+    repeated PlayerInfo playerInfos = 2;
+    int32 f3 = 3;
+}
+
+message GTPC21_6 {
+    repeated GTPC21_6_1 gtpc21_6_1 = 1;
+}
+
+message GTPC21_4 {
+    int32 f1 = 1;
+    string f6 = 6;
+    int32 f7 = 7;
+    int32 f8 = 8;
+}
+
+message GTPC21_8 {
+    int32 f1 = 1;
+    int32 f2 = 2;
+}
+
+message GTPC21 {
+    int32 f1 = 1;
+    GTPC21_4 gtpc21_4 = 4;
+    GTPC21_6 gtpc21_6 = 6;
+    GTPC21_8 gtpc21_8 = 8;
+}
+
+message GameToPhoneCommand {
+    int32 seqno = 1;
+    int32 f2 = 2;
+    GTPC21 gtpc21 = 21;
+}
+
+message GameToPhone {
+    int32 f1 = 1;
+    int32 f2 = 2;
+    int32 id = 3;
+    int32 f4 = 4;
+    int32 f6 = 6;
+    int32 f7 = 7;
+    repeated GameToPhoneCommand commands = 11;
+}
+
+//  ZML client side
+
+message ZMLClientInfo {
+    string appVersion = 1;
+    string systemOSVersion = 2;
+    string systemOS = 3;
+    string systemHardware = 4;
+}
+
+message ZMLClientCapabilities {
+    int32 f1 = 1;
+    ZMLClientInfo info = 5;
+}
+
+message PhoneToGameCommand {
+    int32 seqno = 1;
+    int32 command = 2;
+    int32 subject = 3;
+    int32 f5 = 5;
+    string f6 = 6;
+    int32 f7 = 7;
+    int32 playerId = 19;
+    ZMLClientCapabilities capabilities = 21;
+}
+
+message PhoneToGame {
+    int32 id = 1;
+    PhoneToGameCommand command = 2;
+    int32 f10 = 10;
+}


### PR DESCRIPTION
This is a first pass at providing a way to emulate ZML. This version is fairly basic. I've just reverse engineered enough to get the player map updates. My protobuf decoding may not be correct. I thought I'd publish this in case somebody else is working on something that needs the same functionality.

usage:
				appConnection = account.getProfile(profile.id).getAppConnection()

Appconnection emits connected, msg, and playerInfo events. msg is the entire message, playerInfo just the playerInfo structures received (see proto file for fields).